### PR TITLE
Set hostname to `0.0.0.0`.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -120,7 +120,7 @@ module.exports = function (grunt) {
             site: {
                 options: {
                     base: '<%= meta.rootPath %>',
-                    hostname: 'localhost',
+                    hostname: '0.0.0.0',
                     open: true,
                     livereload: true,
                     port: 8000


### PR DESCRIPTION
Setting it to `'*'`, like '`0.0.0.0`', will make the server accessible
from any **local** IPv4 address like  `'127.0.0.1'` and the IP assigned
to an ethernet or wireless interface (like `'192.168.0.x'` or
`'10.0.0.x'`). [More info](http://en.wikipedia.org/wiki/0.0.0.0)
